### PR TITLE
fix(workflow): allow WebFetch/WebSearch for docs-freshness

### DIFF
--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -40,6 +40,12 @@ jobs:
           claude_code_oauth_token: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--model sonnet"
           show_full_output: true
+          settings: |
+            {
+              "permissions": {
+                "allow": ["WebFetch", "WebSearch"]
+              }
+            }
           prompt: |
             You are a docs-freshness checker. Your job is to compare our reference docs
             against Anthropic's official Claude Code documentation and fix ONLY factual


### PR DESCRIPTION
## Summary

- Add `permissions.allow` settings to grant `WebFetch` and `WebSearch` tools to the Claude agent
- Fixes: the agent was denied web access, so it couldn't fetch official Anthropic docs for comparison

## Note

OAuth token exchange requires the workflow file to match `main` — must merge before testing. After merge, trigger with `gh workflow run docs-freshness.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)