### PR TITLE
Fix sidebar being too wide on laptop screens

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1,0 +1,16 @@
+// Override just-the-docs sidebar expansion formula at lg breakpoint.
+// The default formula absorbs leftover viewport space into the sidebar,
+// making it ~400-450px on laptops. This caps it at the base $nav-width.
+// Mobile dropdown behavior (below md breakpoint) is unaffected.
+
+.side-bar {
+  @media (min-width: 66.5rem) {
+    width: $nav-width;
+  }
+}
+
+.side-bar + .main {
+  @media (min-width: 66.5rem) {
+    margin-left: $nav-width;
+  }
+}


### PR DESCRIPTION
Override the just-the-docs sidebar expansion formula at the lg breakpoint to cap width at $nav-width (16.5rem) instead of absorbing leftover viewport space (~400-450px on 1366-1440px screens).