### PR TITLE
fix: sitemap.xml 404 — align deploy with culture.dev

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,11 +5,6 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: "pages"
   cancel-in-progress: false
@@ -17,6 +12,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,14 +26,13 @@ jobs:
           bundler-cache: true
 
       - name: Setup Pages
-        id: pages
         uses: actions/configure-pages@v5
 
       - name: Initialize search index
         run: bundle exec just-the-docs rake search:init
 
       - name: Build with Jekyll
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production
 
@@ -58,6 +55,8 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
 
   deploy:
     environment:
@@ -65,6 +64,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary

- Moved workflow permissions from top-level to per-job (build gets `contents: read` + `pages: write`, deploy gets `pages: write` + `id-token: write`)
- Removed `--baseurl` override from Jekyll build command — custom domain doesn't need it
- Removed unused `id: pages` from configure-pages step
- Added explicit `path: _site` to upload-pages-artifact

Aligns the GitHub Pages workflow with the working [culture.dev](https://culture.dev) deployment. `jekyll-sitemap` gem was already configured but the `--baseurl` override and permission structure prevented proper sitemap generation.

## Test plan

- [ ] Workflow runs successfully on merge
- [ ] `https://claude-code-guide.org/sitemap.xml` returns 200
- [ ] Sitemap URLs use `https://claude-code-guide.org` base

- Claude