### PR TITLE
Add official docs callout to README and Jekyll landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> **Looking for the official Claude Code guide?** See [Anthropic's Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code/overview).
+> This is a community plugin to help you proactively master Claude Code.
+
 # Claude Code Guide 🌿
 
 <img width="1236" height="380" alt="image" src="https://github.com/user-attachments/assets/1b8117a7-47cf-406b-a2f3-91243879945f" />

--- a/index.md
+++ b/index.md
@@ -4,6 +4,9 @@ nav_order: 0
 permalink: /
 ---
 
+> **Looking for the official Claude Code guide?** See [Anthropic's Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code/overview).
+> This is a community plugin to help you proactively master Claude Code.
+
 # Claude Code Guide
 
 A community guide to **Claude Code** — setup, best practices, automation, and effective workflows.


### PR DESCRIPTION
Points visitors to Anthropic's official Claude Code documentation
and clarifies this is a community plugin for proactive mastery.

https://claude.ai/code/session_01M2z4Yo6sVsDMrV8qeu9ZsC