### PR TITLE
Fix outdated docs and add tasks/worktrees game tracking

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
                   "name": "guide",
                   "source": "./",
                   "description": "Claude Code guide — interactive onboarding walkthrough and Q&A on setup, best practices, automation, and effective workflows",
-                  "version": "2.15.0",
+                  "version": "2.16.0",
                   "license": "CC-BY-4.0",
                   "keywords": ["onboarding", "guide", "tutorial", "best-practices", "automation", "workflows", "migration"]
           }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "guide",
   "description": "A Claude Code guide — skills for interactive onboarding and Q&A on setup, best practices, automation, and effective workflows",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "author": {
     "name": "Ori Nachum"
   },

--- a/hooks/scripts/migrate-data.sh
+++ b/hooks/scripts/migrate-data.sh
@@ -37,7 +37,7 @@ fi
 command -v jq >/dev/null 2>&1 || exit 0
 
 # Define expected feature categories
-EXPECTED='["shell","editing","reading","search","agents","skills","plugins","web","planning","mcp","notebooks","loop","btw"]'
+EXPECTED='["shell","editing","reading","search","agents","skills","plugins","web","planning","mcp","notebooks","loop","btw","tasks","worktrees"]'
 
 # Add missing fields and categories, preserve all existing data
 # Intentionally does not touch pluginVersion or migrations — those are

--- a/hooks/scripts/track-stop.sh
+++ b/hooks/scripts/track-stop.sh
@@ -74,7 +74,7 @@ is_fibonacci "$SESSION" || exit 0
 eval "$(jq -r '
   def multiplier:
     if . == "shell" or . == "editing" or . == "reading" or . == "search" or . == "btw" then 1
-    elif . == "agents" then 100
+    elif . == "agents" or . == "worktrees" then 100
     else 10
     end;
 
@@ -109,15 +109,16 @@ dep_met() {
   local feature="$1"
   case "$feature" in
     agents)       jq -e '.features.skills.count > 0 and .features.planning.count > 0' "$DATA_FILE" >/dev/null 2>&1 ;;
+    worktrees)    jq -e '.features.agents.count > 0' "$DATA_FILE" >/dev/null 2>&1 ;;
     *)            return 0 ;;
   esac
 }
 
 # Level gating: levels 1-2 see intermediate only; 3+ see intermediate + expert
 if [ "$LEVEL" -ge 3 ]; then
-  CANDIDATES="btw skills plugins web planning notebooks mcp loop agents"
+  CANDIDATES="btw skills plugins web planning notebooks mcp loop tasks agents worktrees"
 else
-  CANDIDATES="btw skills plugins web planning notebooks mcp loop"
+  CANDIDATES="btw skills plugins web planning notebooks mcp loop tasks"
 fi
 
 # Filter: unused, not yet suggested, deps met
@@ -140,7 +141,7 @@ if [ -n "$ELIGIBLE" ]; then
   WEIGHTED=""
   for feat in $ELIGIBLE; do
     case "$feat" in
-      agents) WEIGHTED="$WEIGHTED $feat $feat $feat" ;;
+      agents|worktrees) WEIGHTED="$WEIGHTED $feat $feat $feat" ;;
       *)      WEIGHTED="$WEIGHTED $feat" ;;
     esac
   done
@@ -160,6 +161,8 @@ if [ -n "$ELIGIBLE" ]; then
     loop)      TIP="Loop Scheduling — use /loop to monitor deploys or triage tickets on a timer" ;;
     btw)       TIP="Quick Aside — use /btw to ask a one-off question without cluttering context" ;;
     agents)    TIP="Sub Agents — delegate complex tasks to run in parallel" ;;
+    tasks)     TIP="Task Management — use TaskCreate to break work into tracked steps" ;;
+    worktrees) TIP="Worktrees — use isolation: 'worktree' in agents for parallel git work" ;;
     *)         TIP="$PICK" ;;
   esac
 
@@ -170,5 +173,5 @@ if [ -n "$ELIGIBLE" ]; then
 
   echo "🎮 Lvl ${LEVEL} ${TITLE} | ${SCORE} pts | Try: ${TIP} (/guide:level-up for more)"
 else
-  echo "🎮 Lvl ${LEVEL} ${TITLE} | ${SCORE} pts | ${UNIQUE}/13 features (/guide:level-up)"
+  echo "🎮 Lvl ${LEVEL} ${TITLE} | ${SCORE} pts | ${UNIQUE}/15 features (/guide:level-up)"
 fi

--- a/hooks/scripts/track-usage.sh
+++ b/hooks/scripts/track-usage.sh
@@ -53,6 +53,11 @@ case "$TOOL_NAME" in
   WebFetch|WebSearch)            CATEGORY="web" ;;
   EnterPlanMode|ExitPlanMode)    CATEGORY="planning" ;;
   NotebookEdit)                  CATEGORY="notebooks" ;;
+  TaskCreate|TaskGet|TaskList|TaskUpdate|TaskStop|TaskOutput)
+                                 CATEGORY="tasks" ;;
+  EnterWorktree|ExitWorktree)    CATEGORY="worktrees" ;;
+  CronCreate|CronDelete|CronList)
+                                 CATEGORY="loop" ;;
   Agent)
     # Only count user-initiated agents (not built-in or plugin ones)
     SUBAGENT_TYPE="$(echo "$PAYLOAD" | jq -r '.tool_input.subagent_type // empty')"

--- a/skills/ask/references/beginner/built-ins.md
+++ b/skills/ask/references/beginner/built-ins.md
@@ -120,18 +120,27 @@ Claude Code provides these lifecycle events that you can hook into. No hooks are
 | `UserPromptSubmit` | User submits a prompt | Yes |
 | `PreToolUse` | Before a tool call executes | Yes |
 | `PermissionRequest` | Permission dialog appears | Yes |
+| `PermissionDenied` | Tool call denied by auto mode classifier | No |
 | `PostToolUse` | After a tool call succeeds | No |
 | `PostToolUseFailure` | After a tool call fails | No |
 | `Notification` | Claude sends a notification | No |
+| `InstructionsLoaded` | CLAUDE.md or memory files loaded into context | No |
 | `SubagentStart` | A subagent is spawned | No |
 | `SubagentStop` | A subagent finishes | Yes |
 | `Stop` | Claude finishes responding | Yes |
+| `StopFailure` | Turn ends due to an API error | No |
 | `TeammateIdle` | Agent team teammate goes idle | Yes |
+| `TaskCreated` | A task is created via TaskCreate | Yes |
 | `TaskCompleted` | Task is marked as completed | Yes |
+| `FileChanged` | A watched file changes on disk | No |
+| `CwdChanged` | Working directory changes (e.g., cd command) | No |
 | `ConfigChange` | Configuration file changes | Yes (except policy) |
 | `WorktreeCreate` | Worktree is being created | Yes |
 | `WorktreeRemove` | Worktree is being removed | No |
 | `PreCompact` | Before context compaction | No |
+| `PostCompact` | After context compaction completes | No |
+| `Elicitation` | MCP server requests user input during a tool call | Yes |
+| `ElicitationResult` | User responds to an MCP elicitation | No |
 | `SessionEnd` | Session terminates | No |
 
 Hook handlers can be shell commands (`type: "command"`), HTTP endpoints (`type: "http"`), LLM prompts (`type: "prompt"`), or agentic verifiers (`type: "agent"`).

--- a/skills/ask/references/beginner/choosing-your-model.md
+++ b/skills/ask/references/beginner/choosing-your-model.md
@@ -37,12 +37,16 @@ Opus 4.6 and Sonnet 4.6 support **effort levels** that control how deeply the mo
 | **Low** | Minimal reasoning | Fastest | Straightforward tasks: rename a variable, add a log line, simple questions |
 | **Medium** (Opus default) | Balanced reasoning | Moderate | Most daily work: implement features, fix known bugs, write tests |
 | **High** | Deep reasoning | Slowest | Hard problems: architectural design, subtle bugs, complex multi-file changes |
+| **Max** | Deepest reasoning, no token constraint | Slowest | The hardest problems: complex architecture across many files, novel algorithm design. Opus 4.6 only, does not persist across sessions. |
+
+> **Note:** The `max` effort level is available on Opus 4.6 only and does not persist across sessions except through the `CLAUDE_CODE_EFFORT_LEVEL` environment variable.
 
 ### How to set effort level
 
 - **In /model**: use left/right arrow keys to adjust the effort slider
-- **Environment variable**: `export CLAUDE_CODE_EFFORT_LEVEL=low|medium|high`
+- **Environment variable**: `export CLAUDE_CODE_EFFORT_LEVEL=low|medium|high|max`
 - **Settings file**: set `"effortLevel": "medium"` in your settings
+- **Slash command**: `/effort low`, `/effort medium`, `/effort high`, or `/effort max`
 - **One-off deep thinking**: type "ultrathink" anywhere in your prompt to set effort to high for that single turn
 
 ## When to Use Each Model
@@ -102,6 +106,7 @@ Here's how to think about combining model choice and effort level:
 | Debug a race condition | Opus + medium effort | Needs deeper reasoning to trace concurrent paths |
 | Design a caching strategy | Opus + high effort | Complex tradeoffs, needs thorough analysis |
 | Review code for security issues | Opus + high effort | Subtle issues require careful examination |
+| Novel algorithm design or architecture from scratch | Opus + max effort | Deepest possible reasoning with no token constraint |
 | Generate test boilerplate | Sonnet + low effort | Repetitive, well-defined task |
 | Understand unfamiliar codebase | Sonnet + medium effort (or Haiku sub agent) | Balances thoroughness with speed |
 

--- a/skills/ask/references/beginner/starting-to-work.md
+++ b/skills/ask/references/beginner/starting-to-work.md
@@ -42,7 +42,7 @@ You're about to work on something **complex, risky, or unfamiliar** and you want
 In Plan Mode, Claude can read files, search code, and analyze your codebase, but cannot write files or execute commands. It uses `AskUserQuestion` to gather requirements and propose plans.
 
 **The workflow:**
-1. Start in Plan Mode: `claude --permission-mode plan` or press `Shift+Tab` twice
+1. Start in Plan Mode: `claude --permission-mode plan` or press `Shift+Tab` to cycle through modes
 2. Ask Claude to explore and plan: "I need to add OAuth. What files need to change? Create a plan."
 3. Review the plan (press `Ctrl+G` to edit it in your text editor)
 4. Switch to Normal Mode (`Shift+Tab`) and let Claude implement
@@ -183,7 +183,7 @@ Claude implements, and you supervise (Normal) or let it write freely (Accept Edi
 > Commit with a descriptive message and create a PR.
 ```
 
-## 🌿 Beyond the Three Modes: Advanced Options
+## 🌿 Beyond the Permission Modes: Advanced Options
 
 ### `dontAsk` mode
 

--- a/skills/ask/references/beginner/starting-to-work.md
+++ b/skills/ask/references/beginner/starting-to-work.md
@@ -13,7 +13,7 @@ permalink: /starting-to-work/
 
 Before you start typing a prompt, you need to make one key decision: **what permission mode should Claude run in?** This determines how much autonomy Claude has — from read-only exploration to fully autonomous execution.
 
-## The Three Permission Modes
+## Permission Modes
 
 You cycle through modes using **Shift+Tab** during a session, or set them at startup.
 
@@ -21,6 +21,7 @@ You cycle through modes using **Shift+Tab** during a session, or set them at sta
 |---|---|---|---|---|---|
 | **Normal** (default) | (none) | ✅ | ✅ (with approval) | ✅ (with approval) | Yes — for edits and commands |
 | **Accept Edits** | `⏵⏵ accept edits on` | ✅ | ✅ (auto-approved) | ✅ (with approval) | Only for shell commands |
+| **Auto** (research preview) | `🤖 auto mode on` | ✅ | ✅ (auto-approved) | ✅ (auto-approved) | No — background safety checks verify alignment |
 | **Plan Mode** | `⏸ plan mode on` | ✅ | ❌ | ❌ | N/A — Claude only reads and plans |
 
 ## Choosing Your Mode
@@ -106,16 +107,37 @@ File edits (Write, Edit) are auto-approved for the session. Shell commands still
 3. Claude writes files without asking — you only approve shell commands
 4. Review the diff afterward: `/diff` or `git diff`
 
+### Start in Auto mode when...
+
+You **trust Claude to work fully autonomously** with background safety verification. This mode is currently a research preview.
+
+**Typical scenarios:**
+
+- You're working on a well-tested codebase with good CI coverage
+- You want maximum speed and minimal interruptions
+- You're comfortable with Claude making decisions within your project scope
+
+**How it works:**
+Auto-approves tool calls with background safety checks that verify actions align with your request. File edits and shell commands proceed without prompting, but a background classifier flags anything that appears misaligned — those actions are denied and logged in `/permissions`.
+
+**The workflow:**
+1. Press `Shift+Tab` to cycle to Auto mode, or start with `claude --permission-mode auto`
+2. Describe your task and let Claude work
+3. Check `/permissions` to review any denied actions
+4. Configure trusted infrastructure in `autoMode.environment` settings for fewer false positives
+
 ## Decision Flowchart
 
 ```
 Am I exploring or planning?
 ├── Yes → Plan Mode
-│   └── Ready to implement? → Switch to Normal or Accept Edits
+│   └── Ready to implement? → Switch to Normal, Accept Edits, or Auto
 └── No, I'm implementing
-    ├── Do I trust Claude with file edits?
-    │   ├── Yes → Accept Edits mode
-    │   └── Not yet → Normal mode
+    ├── Do I trust Claude to work fully autonomously?
+    │   ├── Yes → Auto mode (research preview)
+    │   └── Do I trust Claude with file edits?
+    │       ├── Yes → Accept Edits mode
+    │       └── Not yet → Normal mode
     └── Is this a quick, low-risk task?
         ├── Yes → Normal mode (just approve as you go)
         └── No, it's complex → Start in Plan Mode first
@@ -188,6 +210,7 @@ An alternative to permission modes — OS-level isolation that restricts filesys
 | Plan a complex change | Plan Mode |
 | Implement with active supervision | Normal |
 | Implement with file-edit freedom | Accept Edits |
+| Let Claude work fully autonomously | Auto (research preview) |
 | Run in CI/automation | `bypassPermissions` (in a sandbox) |
 | Lock down to specific operations | `dontAsk` + allow rules |
 | Ask a quick question without losing context | `/btw` (one-off, stays out of context) |
@@ -196,7 +219,7 @@ An alternative to permission modes — OS-level isolation that restricts filesys
 
 You don't have to pick one mode and stick with it. Switch freely:
 
-- **Shift+Tab**: cycles Normal → Accept Edits → Plan Mode → Normal
+- **Shift+Tab**: cycles Normal → Accept Edits → Auto → Plan Mode → Normal
 - **`/plan`**: enters Plan Mode from the prompt
 - The mode indicator at the bottom of the terminal tells you which mode you're in
 

--- a/skills/ask/references/beginner/starting-to-work.md
+++ b/skills/ask/references/beginner/starting-to-work.md
@@ -107,40 +107,44 @@ File edits (Write, Edit) are auto-approved for the session. Shell commands still
 3. Claude writes files without asking — you only approve shell commands
 4. Review the diff afterward: `/diff` or `git diff`
 
-### Start in Auto mode when...
+### 🌳 Start in Auto mode when...
 
-You **trust Claude to work fully autonomously** with background safety verification. This mode is currently a research preview.
+> **Research preview** — this mode is experimental and may change. It requires understanding its safety model before use.
+
+You **fully understand the safety classifier** and are comfortable with autonomous tool execution. Auto mode is an expert-level capability, not a convenience upgrade from Accept Edits.
 
 **Typical scenarios:**
 
+- You understand how the background safety classifier works and have configured `autoMode.environment`
 - You're working on a well-tested codebase with good CI coverage
-- You want maximum speed and minimal interruptions
-- You're comfortable with Claude making decisions within your project scope
+- You want maximum speed and are prepared to review denied actions after the fact
 
 **How it works:**
-Auto-approves tool calls with background safety checks that verify actions align with your request. File edits and shell commands proceed without prompting, but a background classifier flags anything that appears misaligned — those actions are denied and logged in `/permissions`.
+Auto-approves tool calls with background safety checks that verify actions align with your request. A background classifier evaluates each action — anything that appears misaligned is denied and logged in `/permissions`. You configure trusted infrastructure (repos, domains, buckets) in `autoMode.environment` settings so the classifier knows what's "internal" vs. "external."
 
 **The workflow:**
-1. Press `Shift+Tab` to cycle to Auto mode, or start with `claude --permission-mode auto`
-2. Describe your task and let Claude work
-3. Check `/permissions` to review any denied actions
-4. Configure trusted infrastructure in `autoMode.environment` settings for fewer false positives
+1. Configure `autoMode.environment` in your settings with your trusted infrastructure
+2. Start with `claude --permission-mode auto` or press `Shift+Tab` to cycle to Auto mode
+3. Describe your task and let Claude work
+4. Check `/permissions` to review any denied actions and retry false positives
 
 ## Decision Flowchart
 
 ```
 Am I exploring or planning?
 ├── Yes → Plan Mode
-│   └── Ready to implement? → Switch to Normal, Accept Edits, or Auto
+│   └── Ready to implement? → Switch to Normal or Accept Edits
 └── No, I'm implementing
-    ├── Do I trust Claude to work fully autonomously?
-    │   ├── Yes → Auto mode (research preview)
-    │   └── Do I trust Claude with file edits?
-    │       ├── Yes → Accept Edits mode
-    │       └── Not yet → Normal mode
+    ├── Do I trust Claude with file edits?
+    │   ├── Yes → Accept Edits mode
+    │   └── Not yet → Normal mode
     └── Is this a quick, low-risk task?
         ├── Yes → Normal mode (just approve as you go)
         └── No, it's complex → Start in Plan Mode first
+
+Auto mode (🌳 Expert, research preview):
+  Use only if you fully understand the safety model
+  and are comfortable with autonomous tool execution.
 ```
 
 ## The Explore → Plan → Implement Workflow

--- a/skills/ask/references/intermediate/hooks.md
+++ b/skills/ask/references/intermediate/hooks.md
@@ -150,19 +150,27 @@ exit 0
 | `UserPromptSubmit` | User submits a prompt | Yes |
 | `PreToolUse` | Before a tool call executes | Yes |
 | `PermissionRequest` | Permission dialog appears | Yes |
+| `PermissionDenied` | Tool call denied by auto mode classifier | No |
 | `PostToolUse` | After a tool call succeeds | No (tool already ran) |
 | `PostToolUseFailure` | After a tool call fails | No |
 | `Notification` | Claude sends a notification | No |
+| `InstructionsLoaded` | CLAUDE.md/memory files loaded | No |
 | `SubagentStart` | A subagent is spawned | No |
 | `SubagentStop` | A subagent finishes | Yes |
 | `Stop` | Claude finishes responding | Yes |
-| `InstructionsLoaded` | CLAUDE.md/memory files loaded | No |
-| `ConfigChange` | Settings file changes | Yes |
+| `StopFailure` | Turn ends due to an API error | No |
 | `TeammateIdle` | A teammate has no pending tasks | Yes |
+| `TaskCreated` | A task is created via TaskCreate | Yes |
 | `TaskCompleted` | A background task finishes | Yes |
+| `FileChanged` | A watched file changes on disk | No |
+| `CwdChanged` | Working directory changes (e.g., cd command) | No |
+| `ConfigChange` | Settings file changes | Yes |
 | `WorktreeCreate` | A worktree is created | Yes |
 | `WorktreeRemove` | A worktree is removed | No |
 | `PreCompact` | Before context compaction | No |
+| `PostCompact` | After context compaction completes | No |
+| `Elicitation` | MCP server requests user input during a tool call | Yes |
+| `ElicitationResult` | User responds to an MCP elicitation | No |
 | `SessionEnd` | Session terminates | No |
 
 ## Next Steps

--- a/skills/ask/references/intermediate/loop.md
+++ b/skills/ask/references/intermediate/loop.md
@@ -72,7 +72,7 @@ Each iteration runs in the same conversation, so Claude has full context of prev
 | Constraint | Detail |
 |---|---|
 | **Session-scoped** | Tasks die when your terminal closes, the session exits, or the machine restarts. There is no persistence across sessions. |
-| **3-day auto-expiry** | Recurring tasks automatically expire 3 days after creation — the task fires one final time, then self-deletes. |
+| **7-day auto-expiry** | Recurring tasks automatically expire 7 days after creation — the task fires one final time, then self-deletes. |
 | **50 task limit** | Maximum 50 scheduled tasks per session. |
 | **Fires only when idle** | If Claude is busy when the interval elapses, the task waits. There is no catch-up for missed intervals — it fires once when Claude becomes idle. |
 | **Minute granularity** | The scheduler is cron-based; intervals under 1 minute are rounded up to the nearest minute. |
@@ -81,7 +81,7 @@ Each iteration runs in the same conversation, so Claude has full context of prev
 
 **What this means in practice:**
 
-- The `d` unit exists but is impractical — `/loop 1d` fires roughly 3 times before auto-expiry.
+- The `d` unit exists but is impractical — `/loop 1d` fires roughly 7 times before auto-expiry.
 - Anything longer than a few hours is unreliable. Best practice: intervals from minutes to a few hours within a single working session.
 - For unattended automation that runs without an active session, see [GitHub Actions](github-actions.md).
 
@@ -175,7 +175,7 @@ GitHub Actions is for **unattended automation** — CI/CD pipelines, scheduled m
 | Aspect | /loop | GitHub Actions |
 |---|---|---|
 | **Setup time** | Seconds — just type the command | Minutes to hours — write YAML, configure secrets, push |
-| **Persistence** | Dies with session (3-day max) | Runs on GitHub's infrastructure |
+| **Persistence** | Dies with session (7-day max) | Runs on GitHub's infrastructure |
 | **Reliability** | Depends on session staying alive | Production-grade, team-visible |
 | **Cost model** | Claude tokens per iteration | GitHub Actions minutes + Claude tokens |
 | **Best for** | In-session monitoring, deploy checks, on-call triage | Production workflows, team-wide automation, compliance |

--- a/skills/game-mode/SKILL.md
+++ b/skills/game-mode/SKILL.md
@@ -82,7 +82,9 @@ Present the available commands:
     "mcp":       { "count": 0, "lastUsed": null },
     "notebooks": { "count": 0, "lastUsed": null },
     "loop":      { "count": 0, "lastUsed": null },
-    "btw":       { "count": 0, "lastUsed": null }
+    "btw":       { "count": 0, "lastUsed": null },
+    "tasks":     { "count": 0, "lastUsed": null },
+    "worktrees": { "count": 0, "lastUsed": null }
   },
   "tokens": {
     "read": 0,
@@ -96,7 +98,7 @@ Present the available commands:
 ```
 
 1. Tell the user game mode is now active. Mention:
-   - Tool usage is being tracked across 13 feature categories
+   - Tool usage is being tracked across 15 feature categories
    - Use `/guide:game-mode stats` to see their dashboard
    - Use `/guide:game-mode off` to pause tracking
    - Data is stored locally and never transmitted
@@ -122,8 +124,8 @@ Present the available commands:
 | Tier | Multiplier | Features |
 |---|---|---|
 | Beginner | x1 | shell, editing, reading, search, btw |
-| Intermediate | x10 | skills, plugins, web, planning, notebooks, mcp, loop |
-| Expert | x100 | agents |
+| Intermediate | x10 | skills, plugins, web, planning, notebooks, mcp, loop, tasks |
+| Expert | x100 | agents, worktrees |
 
 1. Compute: `raw_points = sum(feature.count * multiplier)` and `score = sqrt(raw_points)` to 2 decimal places
 1. Count unique features (count > 0)
@@ -159,9 +161,11 @@ Present the available commands:
 |  ⚪ Sub Agents       E       8     800   3h ago       |
 |  ⚪ MCP Tools        I       1      10   7d ago       |
 |  ⚪ Loop/Schedule    I       0       0   never        |
+|  ⚪ Task Mgmt        I       0       0   never        |
+|  ⚪ Worktrees        E       0       0   never        |
 +=======================================================+
 |  Raw: 1053 pts | Score: sqrt(1053) = 32.45            |
-|  Features: 10/13 unlocked                             |
+|  Features: 10/15 unlocked                             |
 |  Tokens: ~12.4K read, ~3.1K write                     |
 |  Next level: Master (score 55+, 10+ features)         |
 |  Migrated: unknown → 2.2.0 (2026-03-09)              |

--- a/skills/level-up/SKILL.md
+++ b/skills/level-up/SKILL.md
@@ -85,7 +85,9 @@ For each feature, determine its state:
 | mcp | Intermediate | — |
 | plugins | Intermediate | — |
 | loop | Intermediate | — |
+| tasks | Intermediate | — |
 | agents | Expert | skills + planning |
+| worktrees | Expert | agents |
 
 Show ALL features in the roadmap, including beginner features. Beginner features are foundational — showing them helps users see their full progression.
 
@@ -114,10 +116,12 @@ Present features grouped by tier with belt emoji, use count, and belt label. Exa
   ⚪ Loop           (5 uses)     White Belt
   ⚪ Planning       (0 uses)     White Belt
   ⚪ Notebooks      (0 uses)     White Belt
+  ⚪ Task Mgmt      (0 uses)     White Belt
                     ⬇️
   Expert
   ────────────────────────────────────────────
   🔒 Sub Agents     (needs: planning)
+  🔒 Worktrees      (needs: agents)
 
 ═══════════════════════════════════════════════
   ⚪ White  🟡 Yellow  🟠 Orange  🟢 Green
@@ -149,10 +153,12 @@ Advanced user example with dans:
   🟤 Loop           (480 uses)   Brown Belt
   🟠 Planning       (45 uses)    Orange Belt
   🟡 Notebooks      (16 uses)    Yellow Belt
+  🟠 Task Mgmt      (38 uses)    Orange Belt
                     ⬇️
   Expert
   ────────────────────────────────────────────
   🟢 Sub Agents     (72 uses)    Green Belt
+  🟡 Worktrees      (20 uses)    Yellow Belt
 
 ═══════════════════════════════════════════════
   ⚪ White  🟡 Yellow  🟠 Orange  🟢 Green
@@ -185,6 +191,8 @@ Present a short, positive recommendation:
 **Examples:**
 
 - White Belt: "**Try Planning** ⚪ — structure complex tasks before diving in. Ask Claude to make a plan for your next feature."
+- White Belt: "**Try Task Management** ⚪ — break complex work into tracked steps. Use TaskCreate to organize multi-step implementations."
+- White Belt: "**Try Worktrees** ⚪ — run agents in isolated git worktrees for parallel work without branch conflicts."
 - Yellow Belt: "**Deepen MCP Tools** 🟡 — you've started exploring external integrations. Try connecting a database or API server to unlock more power."
 - All features Green+: "**Level up Sub Agents** 🟢 — your weakest area. Delegate a research task to a sub-agent while you keep working."
 

--- a/tests/helpers/setup.sh
+++ b/tests/helpers/setup.sh
@@ -17,7 +17,9 @@ GAME_DATA_TEMPLATE='{
     "mcp": {"count": 0, "lastUsed": null},
     "notebooks": {"count": 0, "lastUsed": null},
     "loop": {"count": 0, "lastUsed": null},
-    "btw": {"count": 0, "lastUsed": null}
+    "btw": {"count": 0, "lastUsed": null},
+    "tasks": {"count": 0, "lastUsed": null},
+    "worktrees": {"count": 0, "lastUsed": null}
   },
   "tokens": {"read": 0, "write": 0, "total": 0},
   "sessionCount": 0,

--- a/tests/migrate-data.bats
+++ b/tests/migrate-data.bats
@@ -20,16 +20,16 @@ run_migrate() {
   # Start with minimal game-data.json — only enabled and empty features
   echo '{"enabled": true, "features": {}}' > "$DATA_FILE"
   run_migrate
-  # All 13 categories should exist
+  # All 15 categories should exist
   local count
   count="$(jq '.features | keys | length' "$DATA_FILE")"
-  [ "$count" -eq 13 ]
+  [ "$count" -eq 15 ]
 }
 
-@test "All 13 expected categories are present after migration" {
+@test "All 15 expected categories are present after migration" {
   echo '{"enabled": true, "features": {}}' > "$DATA_FILE"
   run_migrate
-  for cat in shell editing reading search agents skills plugins web planning mcp notebooks loop btw; do
+  for cat in shell editing reading search agents skills plugins web planning mcp notebooks loop btw tasks worktrees; do
     local val
     val="$(jq -r --arg c "$cat" '.features[$c]' "$DATA_FILE")"
     [ "$val" != "null" ]
@@ -143,7 +143,7 @@ run_migrate() {
   echo '{"enabled": true, "features": {}}' > "$DATA_FILE"
   run_migrate
   # Validate each new feature category has count and lastUsed
-  for cat in shell editing reading search agents skills plugins web planning mcp notebooks loop btw; do
+  for cat in shell editing reading search agents skills plugins web planning mcp notebooks loop btw tasks worktrees; do
     [ "$(jq -r --arg c "$cat" '.features[$c].count' "$DATA_FILE")" = "0" ]
     [ "$(jq -r --arg c "$cat" '.features[$c].lastUsed' "$DATA_FILE")" = "null" ]
   done

--- a/tests/track-stop.bats
+++ b/tests/track-stop.bats
@@ -208,7 +208,7 @@ run_hook() {
 @test "Already-suggested features are not re-suggested" {
   # Suggest all eligible features until none remain
   # Pre-populate suggestedFeatures with all level 1-2 candidates
-  jq '.suggestedFeatures = ["btw","skills","plugins","web","planning","notebooks","mcp","loop"]' \
+  jq '.suggestedFeatures = ["btw","skills","plugins","web","planning","notebooks","mcp","loop","tasks"]' \
     "$DATA_FILE" > "${DATA_FILE}.tmp" && mv "${DATA_FILE}.tmp" "$DATA_FILE"
   output="$(run_hook '{"usage": {"input_tokens": 0, "output_tokens": 0}}')"
   # Should show the "features" summary line instead of "Try:"

--- a/tests/track-usage.bats
+++ b/tests/track-usage.bats
@@ -114,6 +114,52 @@ run_hook() {
   [ "$(get_count agents)" -eq 1 ]
 }
 
+# --- Task tracking ---
+
+@test "TaskCreate tool increments tasks count" {
+  run_hook '{"tool_name": "TaskCreate"}'
+  [ "$(get_count tasks)" -eq 1 ]
+}
+
+@test "TaskUpdate tool increments tasks count" {
+  run_hook '{"tool_name": "TaskUpdate"}'
+  [ "$(get_count tasks)" -eq 1 ]
+}
+
+@test "TaskList tool increments tasks count" {
+  run_hook '{"tool_name": "TaskList"}'
+  [ "$(get_count tasks)" -eq 1 ]
+}
+
+# --- Worktree tracking ---
+
+@test "EnterWorktree tool increments worktrees count" {
+  run_hook '{"tool_name": "EnterWorktree"}'
+  [ "$(get_count worktrees)" -eq 1 ]
+}
+
+@test "ExitWorktree tool increments worktrees count" {
+  run_hook '{"tool_name": "ExitWorktree"}'
+  [ "$(get_count worktrees)" -eq 1 ]
+}
+
+# --- Cron tools tracked as loop ---
+
+@test "CronCreate tool increments loop count" {
+  run_hook '{"tool_name": "CronCreate"}'
+  [ "$(get_count loop)" -eq 1 ]
+}
+
+@test "CronDelete tool increments loop count" {
+  run_hook '{"tool_name": "CronDelete"}'
+  [ "$(get_count loop)" -eq 1 ]
+}
+
+@test "CronList tool increments loop count" {
+  run_hook '{"tool_name": "CronList"}'
+  [ "$(get_count loop)" -eq 1 ]
+}
+
 # --- Plan-file detection ---
 
 @test "Write to plans directory increments planning count" {

--- a/tests/track-usage.bats
+++ b/tests/track-usage.bats
@@ -131,6 +131,21 @@ run_hook() {
   [ "$(get_count tasks)" -eq 1 ]
 }
 
+@test "TaskGet tool increments tasks count" {
+  run_hook '{"tool_name": "TaskGet"}'
+  [ "$(get_count tasks)" -eq 1 ]
+}
+
+@test "TaskStop tool increments tasks count" {
+  run_hook '{"tool_name": "TaskStop"}'
+  [ "$(get_count tasks)" -eq 1 ]
+}
+
+@test "TaskOutput tool increments tasks count" {
+  run_hook '{"tool_name": "TaskOutput"}'
+  [ "$(get_count tasks)" -eq 1 ]
+}
+
 # --- Worktree tracking ---
 
 @test "EnterWorktree tool increments worktrees count" {


### PR DESCRIPTION
## Summary

Closes #45

- **Docs freshness**: Fix 5 outdated reference docs identified by the weekly docs-freshness check
  - Add `auto` permission mode (research preview) to starting-to-work.md
  - Add `max` effort level (Opus 4.6 only) to choosing-your-model.md
  - Add 9 missing hook events to built-ins.md (17→26 total)
  - Add 8 missing hook events to hooks.md (18→26 total)
  - Fix 3-day→7-day auto-expiry in loop.md (critical factual error)
- **New game tracking**: Expand from 13→15 tracked feature categories
  - `tasks` (Intermediate, x10): tracks TaskCreate/Get/List/Update/Stop/Output
  - `worktrees` (Expert, x100): tracks EnterWorktree/ExitWorktree, depends on agents
  - Cron tools (CronCreate/Delete/List) now tracked under existing `loop` category
- **Updated**: game-mode SKILL.md, level-up SKILL.md, migrate-data.sh, all hook scripts
- **Version**: 2.15.0 → 2.16.0

## Test plan

- [x] All 93 bats tests pass (including 8 new tests for task/worktree/cron tool mappings)
- [x] Verify auto mode section reads correctly in starting-to-work.md
- [x] Verify max effort level section reads correctly in choosing-your-model.md
- [x] Verify hook event tables have 26 entries in both built-ins.md and hooks.md
- [x] Verify loop.md references 7-day expiry consistently
- [x] Verify game-mode stats dashboard shows 15 features
- [x] Verify level-up roadmap includes tasks and worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude