### PR TITLE
Add doc-test alignment check to introspect skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
                   "name": "guide",
                   "source": "./",
                   "description": "Claude Code guide — interactive onboarding walkthrough and Q&A on setup, best practices, automation, and effective workflows",
-                  "version": "2.17.2",
+                  "version": "2.18.0",
                   "license": "CC-BY-4.0",
                   "keywords": ["onboarding", "guide", "tutorial", "best-practices", "automation", "workflows", "migration"]
           }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
                   "name": "guide",
                   "source": "./",
                   "description": "Claude Code guide — interactive onboarding walkthrough and Q&A on setup, best practices, automation, and effective workflows",
-                  "version": "2.17.1",
+                  "version": "2.17.2",
                   "license": "CC-BY-4.0",
                   "keywords": ["onboarding", "guide", "tutorial", "best-practices", "automation", "workflows", "migration"]
           }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "guide",
   "description": "A Claude Code guide — skills for interactive onboarding and Q&A on setup, best practices, automation, and effective workflows",
-  "version": "2.17.2",
+  "version": "2.18.0",
   "author": {
     "name": "Ori Nachum"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "guide",
   "description": "A Claude Code guide — skills for interactive onboarding and Q&A on setup, best practices, automation, and effective workflows",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "author": {
     "name": "Ori Nachum"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,21 @@ Installed plugins are cached at `~/.claude/plugins/cache`. **Version is the cach
 
 Before staging or committing changes, check the current branch. If you are on `main`, create a new descriptive branch first — never commit directly to `main`.
 
+### After implementing a plan
+
+When a plan's implementation is complete, run the PR review cycle:
+
+1. **Branch** — if on `main`, create a descriptive branch (`feature/short-name`)
+2. **Commit & push** — stage only files changed by the task (never `git add -A`), commit, push with `-u`
+3. **Create PR** — `gh pr create` with a summary of the changes
+4. **Wait for reviewers** — wait ~5 minutes, then check for automated review comments and CI status
+5. **Triage in plan mode** — enter plan mode and categorize each comment: fix, fix + pushback, pushback, or acknowledge
+6. **Fix & push** — apply approved fixes, commit, push
+7. **Follow-up issues** — open GitHub issues for items outside the PR's scope
+8. **Reply & resolve** — reply to every comment thread and resolve it
+
+Use the `pr-review` agent (`agents/pr-review.md`) and its helper scripts to automate steps 4-8.
+
 ### After completing work
 
 When a task is done and merged, clean up:

--- a/skills/ask/references/expert/introspective-development.md
+++ b/skills/ask/references/expert/introspective-development.md
@@ -45,6 +45,7 @@ After producing documentation, deliberately review it through different lenses:
 - **AI conversations** — discuss docs with agents: "explain this back to me," "what's missing," "what would confuse a newcomer"
 - **User-story demos** — write scenarios that walk through actual usage, revealing design gaps
 - **Fix-forward cycle** — issues found flow back as tasks: bug fixes, doc rewrites, design improvements
+- **Doc-test alignment** — verify a mechanism exists (skill, CI step, agent) that checks docs describe what tests assert and tests cover what docs promise
 
 This is the "documentation as code, NotebookLM as compiler" principle. If the compiled output (podcast, overview, summary) sounds wrong, the source docs need fixing.
 
@@ -69,7 +70,7 @@ Introspective Development verifies that a project supports every phase of the de
 |---|---|
 | **Plan** | Architecture docs exist, planning guidance in CLAUDE.md or a skill |
 | **Implement** | Code is navigable — conventions documented, scripts reduce complexity |
-| **Test** | Test suite exists, CI runs it, agent knows how to invoke tests |
+| **Test** | Test suite exists, CI runs it, agent knows how to invoke tests, doc-test alignment is verified |
 | **PR** | PR workflow documented or scripted — format, checks, reviewers |
 | **Iterate** | Review feedback loop works — agent can read comments, fix, push |
 | **Clear** | Agent knows how to clean up — compact history, archive, close |

--- a/skills/ask/references/expert/introspective-development.md
+++ b/skills/ask/references/expert/introspective-development.md
@@ -45,7 +45,7 @@ After producing documentation, deliberately review it through different lenses:
 - **AI conversations** — discuss docs with agents: "explain this back to me," "what's missing," "what would confuse a newcomer"
 - **User-story demos** — write scenarios that walk through actual usage, revealing design gaps
 - **Fix-forward cycle** — issues found flow back as tasks: bug fixes, doc rewrites, design improvements
-- **Doc-test alignment** — verify a mechanism exists (skill, CI step, agent) that checks docs describe what tests assert and tests cover what docs promise
+- **Doc-test alignment** — verify a mechanism exists (sub-agent, skill, or hook) that checks docs describe what tests assert and tests cover what docs promise
 
 This is the "documentation as code, NotebookLM as compiler" principle. If the compiled output (podcast, overview, summary) sounds wrong, the source docs need fixing.
 

--- a/skills/introspect/SKILL.md
+++ b/skills/introspect/SKILL.md
@@ -107,7 +107,7 @@ Gather project state relevant to the focus. Read what exists, note what's missin
 | **MCP servers / agent skills** | `.mcp.json`, settings — what external integrations are wired? |
 | **Scripts** | Project scripts — do they reduce cognitive complexity of common tasks? |
 | **Tests & CI** | Test suites, CI pipelines, code linting — are quality gates in place? |
-| **Doc-test alignment** | Is there a sub-agent, skill, CI check, or process that verifies docs describe what tests assert and vice versa? |
+| **Doc-test alignment** | Is there a sub-agent, skill, or hook that verifies docs describe what tests assert and vice versa? |
 | **Markdown linting** | markdownlint config, `.markdownlint-cli2.yaml` — is doc quality enforced? |
 | **Docs** | README, `docs/`, references — are they fresh, accurate, consumable? |
 | **Git history** | Recent commits — what workflow patterns are visible? |
@@ -135,7 +135,7 @@ Evaluate findings through the four dimensions of Introspective Development:
 - Are docs consumable by tools like NotebookLM (documentation as code, NotebookLM as compiler)?
 - Are there gaps, contradictions, or stale information?
 - Is there a linting setup for docs quality?
-- Is there a mechanism (sub-agent, skill, CI step, or documented process) to verify that docs and tests stay in sync?
+- Is there a mechanism (sub-agent, skill, or hook) to verify that docs and tests stay in sync?
 
 #### Dimension 4: Environment Self-Improvement
 

--- a/skills/introspect/SKILL.md
+++ b/skills/introspect/SKILL.md
@@ -107,6 +107,7 @@ Gather project state relevant to the focus. Read what exists, note what's missin
 | **MCP servers / agent skills** | `.mcp.json`, settings — what external integrations are wired? |
 | **Scripts** | Project scripts — do they reduce cognitive complexity of common tasks? |
 | **Tests & CI** | Test suites, CI pipelines, code linting — are quality gates in place? |
+| **Doc-test alignment** | Is there a sub-agent, skill, CI check, or process that verifies docs describe what tests assert and vice versa? |
 | **Markdown linting** | markdownlint config, `.markdownlint-cli2.yaml` — is doc quality enforced? |
 | **Docs** | README, `docs/`, references — are they fresh, accurate, consumable? |
 | **Git history** | Recent commits — what workflow patterns are visible? |
@@ -134,6 +135,7 @@ Evaluate findings through the four dimensions of Introspective Development:
 - Are docs consumable by tools like NotebookLM (documentation as code, NotebookLM as compiler)?
 - Are there gaps, contradictions, or stale information?
 - Is there a linting setup for docs quality?
+- Is there a mechanism (sub-agent, skill, CI step, or documented process) to verify that docs and tests stay in sync?
 
 #### Dimension 4: Environment Self-Improvement
 
@@ -149,7 +151,7 @@ Evaluate whether the project supports each phase of the development lifecycle:
 |---|---|
 | **Plan** | Architecture docs exist, planning guidance in CLAUDE.md or a skill |
 | **Implement** | Code is navigable — conventions documented, scripts reduce complexity |
-| **Test** | Test suite exists, CI runs it, agent knows how to invoke (documented or scripted) |
+| **Test** | Test suite exists, CI runs it, agent knows how to invoke (documented or scripted), doc-test alignment is verified |
 | **PR** | PR workflow is documented or scripted — what to include, format, checks |
 | **Iterate** | Review feedback loop works — agent can read comments, fix, push |
 | **Clear** | Agent knows how to clean up — compact history, archive, close |
@@ -210,6 +212,7 @@ Apply only the approved fixes. For each fix:
 - Add or update linting configs
 - Update existing skill descriptions
 - Add instructions to existing PR review skills
+- Suggest or create a doc-test alignment sub-agent stub (modeled after `pr-review`) to run at the end of a plan
 
 **What you do NOT do:**
 


### PR DESCRIPTION
## Summary
- Introspect now checks whether projects have a mechanism (sub-agent, skill, CI check) to verify docs and tests stay in sync
- When missing, the suggested fix is to create a doc-test alignment sub-agent modeled after `pr-review`
- Adds "After implementing a plan" section to CLAUDE.md documenting the standard PR review cycle (branch, push, PR, wait, triage, fix, reply, resolve)
- Patch version bump: 2.17.1 → 2.17.2

## Test plan
- [x] All 98 bats tests pass
- [x] markdownlint clean on SKILL.md and CLAUDE.md
- [ ] Run `/guide:introspect` and confirm doc-test alignment appears in scan and report

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude